### PR TITLE
feat: Add ADB device detection and selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - **🤖 Robust Bot System**: Dual detection (image + OCR) for reliable race fail handling
 - **⚡ Performance Optimization**: JSON-based data loading for faster operation
 - **🔧 Technical Upgrades**: Modern build system with automated releases
+- **📱 Smart Device Detection**: Automatic ADB device detection and selection
 
 ### 🆕 **New Features**
 - **Advanced Race Filtering**: Filter by race type, distance, terrain, and event character
@@ -19,6 +20,7 @@
 - **Event Choice Picker**: Smart event selection for optimal training
 - **70% English Translation**: Major UI and system text translated to English
 - **Automated Releases**: GitHub Actions for seamless executable distribution
+- **Auto Device Selection**: Interactive ADB device detection and selection
 
 ### 🔄 **Current Limitations**
 - **Uma Musume Selection**: Must be done manually in-game (not yet automated)
@@ -60,27 +62,11 @@ cd UAT-Global-Server
 2. Run `install.ps1` (Right-click → "Run with PowerShell")
 3. Ensure no `venv` folder exists in current directory
 
-### **Configuration**
-
-Edit `config.yaml`:
-
-```yaml
-bot:
-  auto:
-    adb:
-      device_name: "127.0.0.1:16384"  # Your emulator's ADB port
-      delay: 0
-    cpu_alloc: 4  # Number of allocated CPUs
-```
-
-**Common Emulator Ports:**
-- **MuMu12** (Recommended): `127.0.0.1:16384`
-- **LDPlayer/BlueStacks**: `emulator-5554`
-
 ### **Emulator Setup**
 - **Resolution**: 720 × 1280 (Portrait mode)
 - **DPI**: 180
 - **Graphics**: Standard (not Simple)
+- **ADB**: Must be enabled in emulator settings
 
 ### **Launch**
 ```bash
@@ -88,9 +74,17 @@ bot:
 ./run.ps1
 ```
 
+The application will automatically:
+1. 🔍 **Scan for ADB devices**
+2. 📱 **Show available devices**
+3. 🎮 **Detect devices with Umamusume running**
+4. ✅ **Let you select your preferred device**
+5. ⚙️ **Auto-update configuration**
+6. 🚀 **Start the web interface**
+
 **Success indicator:**
 ```
-UAT running on http://127.0.0.1:8071
+🚀 UAT running on http://127.0.0.1:8071
 ```
 
 Access the web interface at `http://127.0.0.1:8071` to configure and start tasks.
@@ -119,6 +113,11 @@ Access the web interface at `http://127.0.0.1:8071` to configure and start tasks
 ## 🔧 **Troubleshooting**
 
 ### **Common Issues**
+
+#### **ADB Device Detection**
+- **No devices found**: Ensure emulator is running and ADB is enabled
+- **ADB server issues**: The app automatically restarts ADB server if needed
+- **Device not detected**: Check emulator's ADB settings and USB debugging
 
 #### **PowerShell Script Issues**
 - **Script crashes**: Open console first to see error messages
@@ -166,6 +165,7 @@ Access the web interface at `http://127.0.0.1:8071` to configure and start tasks
 - ✅ **Web Interface Enhancement**: Advanced filtering and controls
 - ✅ **Performance Optimization**: JSON-based data loading
 - ✅ **Error Handling**: Robust fail-safe mechanisms
+- ✅ **Smart Device Detection**: Automatic ADB device selection
 
 ## 🤝 **Contributing**
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,7 @@
-version: 0.0.1
 bot:
   auto:
     adb:
-      device_name: "127.0.0.1:5555"
       delay: 0.5
+      device_name: emulator-5554
     cpu_alloc: 4
-
-
+version: 0.0.1

--- a/main.py
+++ b/main.py
@@ -1,18 +1,177 @@
 import sys
 import threading
+import subprocess
+import os
+import yaml
 
 from bot.base.manifest import register_app
 from bot.engine.scheduler import scheduler
 from module.umamusume.manifest import UmamusumeManifest
 from uvicorn import run
 
+
+def get_adb_devices():
+    """Get list of connected ADB devices"""
+    try:
+        # Use the adb from deps directory
+        adb_path = os.path.join("deps", "adb", "adb.exe")
+        
+        if not os.path.exists(adb_path):
+            print("❌ ADB not found in deps/adb/ directory")
+            return []
+        
+        # First try to get devices
+        result = subprocess.run([adb_path, "devices"], 
+                              capture_output=True, text=True, timeout=10)
+        
+        if result.returncode != 0:
+            print(f"❌ ADB error: {result.stderr}")
+            return []
+        
+        devices = []
+        lines = result.stdout.strip().split('\n')[1:]  # Skip header line
+        
+        for line in lines:
+            if line.strip() and '\t' in line:
+                device_id, status = line.split('\t')
+                if status == 'device':
+                    devices.append(device_id)
+        
+        # If no devices found, try restarting ADB server
+        if not devices:
+            print("🔄 No devices found, restarting ADB server...")
+            subprocess.run([adb_path, "kill-server"], capture_output=True, timeout=5)
+            subprocess.run([adb_path, "start-server"], capture_output=True, timeout=10)
+            
+            # Try again after restart
+            result = subprocess.run([adb_path, "devices"], 
+                                  capture_output=True, text=True, timeout=10)
+            
+            if result.returncode == 0:
+                lines = result.stdout.strip().split('\n')[1:]
+                for line in lines:
+                    if line.strip() and '\t' in line:
+                        device_id, status = line.split('\t')
+                        if status == 'device':
+                            devices.append(device_id)
+        
+        return devices
+    except Exception as e:
+        print(f"❌ Error getting ADB devices: {e}")
+        return []
+
+
+def check_umamusume_running(device_id):
+    """Check if Umamusume is running on the device"""
+    try:
+        adb_path = os.path.join("deps", "adb", "adb.exe")
+        cmd = [adb_path, "-s", device_id, "shell", "dumpsys", "activity", "activities"]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        
+        if result.returncode == 0:
+            # Look for Umamusume package in running activities
+            output = result.stdout.lower()
+            umamusume_packages = [
+                "com.cygames.umamusume",
+                "jp.co.cygames.umamusume",
+                "umamusume"
+            ]
+            return any(pkg in output for pkg in umamusume_packages)
+    except:
+        pass
+    return False
+
+
+def select_device():
+    """Let user select an ADB device"""
+    print("🔍 Scanning for ADB devices...")
+    devices = get_adb_devices()
+    
+    if not devices:
+        print("❌ No ADB devices found!")
+        print("Please ensure:")
+        print("1. Your emulator is running")
+        print("2. ADB is enabled in emulator settings")
+        print("3. USB debugging is enabled")
+        return None
+    
+    print(f"\n📱 Found {len(devices)} device(s):")
+    
+    # Check which devices have Umamusume running
+    device_info = []
+    for i, device_id in enumerate(devices, 1):
+        has_umamusume = check_umamusume_running(device_id)
+        status = "🎮 Umamusume Running" if has_umamusume else "📱 Device Connected"
+        device_info.append((device_id, has_umamusume))
+        print(f"{i}. {device_id} - {status}")
+    
+    # Prioritize devices with Umamusume running
+    umamusume_devices = [d for d, has_uma in device_info if has_uma]
+    other_devices = [d for d, has_uma in device_info if not has_uma]
+    
+    if umamusume_devices:
+        print(f"\n🎯 Recommended devices (Umamusume detected):")
+        for i, device_id in enumerate(umamusume_devices, 1):
+            print(f"  {i}. {device_id}")
+    
+    while True:
+        try:
+            choice = input(f"\nSelect device (1-{len(devices)}) or 'q' to quit: ").strip()
+            if choice.lower() == 'q':
+                return None
+            
+            choice_num = int(choice)
+            if 1 <= choice_num <= len(devices):
+                selected_device = devices[choice_num - 1]
+                print(f"✅ Selected device: {selected_device}")
+                return selected_device
+            else:
+                print("❌ Invalid choice. Please try again.")
+        except ValueError:
+            print("❌ Please enter a valid number.")
+        except KeyboardInterrupt:
+            print("\n👋 Goodbye!")
+            return None
+
+
+def update_config(device_name):
+    """Update config.yaml with selected device"""
+    try:
+        with open("config.yaml", 'r', encoding='utf-8') as f:
+            config = yaml.safe_load(f)
+        
+        config['bot']['auto']['adb']['device_name'] = device_name
+        
+        with open("config.yaml", 'w', encoding='utf-8') as f:
+            yaml.dump(config, f, default_flow_style=False, allow_unicode=True)
+        
+        print(f"✅ Updated config.yaml with device: {device_name}")
+        return True
+    except Exception as e:
+        print(f"❌ Error updating config: {e}")
+        return False
+
+
 if __name__ == '__main__':
     if sys.version_info.minor != 10 or sys.version_info.micro != 9:
         print("\033[33m{}\033[0m".format("注意：python 版本号不正确，可能无法正常运行"))
         print("建议python版本：3.10.9 当前：" + sys.version)
+    
+    # Device selection
+    selected_device = select_device()
+    if selected_device is None:
+        print("❌ No device selected. Exiting.")
+        sys.exit(1)
+    
+    # Update config with selected device
+    if not update_config(selected_device):
+        print("❌ Failed to update config. Exiting.")
+        sys.exit(1)
+    
+    # Start the bot
     register_app(UmamusumeManifest)
     scheduler_thread = threading.Thread(target=scheduler.init, args=())
     scheduler_thread.start()
-    print("UAT running on http://127.0.0.1:8071")
+    print("🚀 UAT running on http://127.0.0.1:8071")
     run("bot.server.handler:server", host="127.0.0.1", port=8071, log_level="error")
 


### PR DESCRIPTION
## Feature: Automatic ADB Device Detection & Selection

### What's Changed

- **Interactive ADB device selection**: When running `python main.py`, users are prompted to select from detected ADB devices.
- **Umamusume detection**: Devices running Umamusume are highlighted as recommended.
- **No manual config editing**: The selected device is automatically written to `config.yaml`.
- **ADB server auto-restart**: If no devices are found, the script restarts the ADB server and retries.
- **README.md updated**: Setup and troubleshooting instructions now reflect the new workflow.

### Why?

- Simplifies setup for new and existing users.
- Eliminates the need to manually edit `config.yaml` for device selection.
- Reduces user error and confusion during first-time setup.
- Improves reliability by handling ADB server issues automatically.

### How to Use

1. Start your emulator and ensure ADB is enabled.
2. Run:
   ```bash
   python main.py
   ```
3. Select your device from the prompt.
4. The bot will launch and open the web interface as usual.

### Additional Notes

- This is a small code change but a big improvement for user experience.
- If no devices are detected, the script will attempt to restart the ADB server automatically.
- The README now documents the new workflow and troubleshooting steps for ADB issues.

**Ready for review!**