### PR TITLE
fix: Resolve Gold Ship's restricted training loop

### DIFF
--- a/module/umamusume/script/cultivate_task/cultivate.py
+++ b/module/umamusume/script/cultivate_task/cultivate.py
@@ -247,7 +247,10 @@ def script_cultivate_training_select(ctx: UmamusumeContext):
                         img = ctx.ctrl.get_screen()
                         retry += 1
                     if retry == max_retry:
-                        return
+                        # Training is restricted by the game - clear it and continue
+                        log.info(f"🚫 Training {TrainingType(i + 1).name} is restricted by game - skipping")
+                        _clear_training(ctx, TrainingType(i + 1))
+                        continue
                     
                     thread = threading.Thread(target=_parse_training_in_thread,
                                             args=(ctx, img, TrainingType(i + 1)))


### PR DESCRIPTION
PR will fix the Issue #9.

How It Works:
1. When the system tries to parse a restricted training and fails after 3 retries.
2. Instead of getting stuck, it logs the restriction and clears that training data.
3. Moves on to parse the next available training option.
4. AI only considers available training options for decision making.
5. No more infinite loops trying to access restricted training.